### PR TITLE
Add GetServerListAsync for INacosServerManager

### DIFF
--- a/src/Nacos.AspNetCore/INacosServerManager.cs
+++ b/src/Nacos.AspNetCore/INacosServerManager.cs
@@ -1,5 +1,6 @@
 ﻿namespace Nacos.AspNetCore
 {
+    using System.Collections.Generic;
     using System.Threading.Tasks;
 
     public interface INacosServerManager
@@ -11,5 +12,13 @@
         Task<string> GetServerAsync(string serviceName, string groupName, string clusters);
 
         Task<string> GetServerAsync(string serviceName, string groupName, string clusters, string namespaceId);
+
+        Task<List<Host>> GetServerListAsync(string serviceName);
+
+        Task<List<Host>> GetServerListAsync(string serviceName, string groupName);
+
+        Task<List<Host>> GetServerListAsync(string serviceName, string groupName, string clusters);
+
+        Task<List<Host>> GetServerListAsync(string serviceName, string groupName, string clusters, string namespaceId);
     }
 }

--- a/src/Nacos.AspNetCore/NacosServerManager.cs
+++ b/src/Nacos.AspNetCore/NacosServerManager.cs
@@ -91,10 +91,10 @@
 
 
         /// <summary>
-        /// 获取该服务的Host列表
+        /// Get the Host list of the service named serviceName
         /// </summary>
-        /// <param name="serviceName">服务名</param>
-        /// <returns>Host列表</returns>
+        /// <param name="serviceName">ServiceName</param>
+        /// <returns>Host list</returns>
         public async Task<List<Host>> GetServerListAsync(string serviceName)
         {
             return await GetServerListInnerAsync(serviceName, null, null, null);


### PR DESCRIPTION
原因: ocelot 使用服务发现 IServiceDiscoveryProvider接口需实现 ``` Task<List<Service>> Get();```
原GetServerAsync方法 根据权重只返回一个url.
故新增GetServerListAsync返回``` List<Host> ```, 根据host列表 组装``` List<Service> ```
参考: https://github.com/softlgl/Ocelot.Provider.Nacos