### PR TITLE
If there is more than one network adapter

### DIFF
--- a/src/Nacos.AspNetCore/NacosAspNetCoreOptions.cs
+++ b/src/Nacos.AspNetCore/NacosAspNetCoreOptions.cs
@@ -49,6 +49,12 @@
         public string Ip { get; set; }
 
         /// <summary>
+        /// Select an IP that matches the prefix as the service registration IP
+        /// like the config of spring.cloud.inetutils.preferred-networks
+        /// </summary>
+        public string PreferredNetworks { get; set; }
+
+        /// <summary>
         /// the port of this instance
         /// </summary>
         public int Port { get; set; }

--- a/src/Nacos.AspNetCore/StatusReportBgTask.cs
+++ b/src/Nacos.AspNetCore/StatusReportBgTask.cs
@@ -210,19 +210,23 @@
 
             try
             {
-                IPHostEntry ipHost = Dns.GetHostEntry(Dns.GetHostName());
-
                 foreach (var ipAddr in Dns.GetHostAddresses(Dns.GetHostName()))
                 {
-                    if (ipAddr.AddressFamily.ToString() == "InterNetwork")
+                    if (ipAddr.AddressFamily.ToString() != "InterNetwork") continue;
+                    if (string.IsNullOrEmpty(_options.PreferredNetworks))
                     {
                         instanceIp = ipAddr.ToString();
                         break;
                     }
+
+                    if (!ipAddr.ToString().StartsWith(_options.PreferredNetworks)) continue;
+                    instanceIp = ipAddr.ToString();
+                    break;
                 }
             }
             catch
             {
+                // ignored
             }
 
             return instanceIp;


### PR DESCRIPTION
solve the problem:
 If there is more than one network adapter, the method ```GetCurrentIp()``` always get the first network adapter's Ip
1.```NacosAspNetCoreOptions``` add property ```PreferredNetworks```
2. modify the method ```GetCurrentIp()``` of class ```StatusReportBgTask```