### PR TITLE
fixed issue (#119)

### DIFF
--- a/src/Nacos.Microsoft.Extensions.Configuration/NacosV2ConfigurationProvider.cs
+++ b/src/Nacos.Microsoft.Extensions.Configuration/NacosV2ConfigurationProvider.cs
@@ -198,7 +198,7 @@
 
                         foreach (var item in data)
                         {
-                            nData.Add(item.Key, item.Value);
+                            nData[item.Key] = item.Value;
                         }
                     }
 


### PR DESCRIPTION
When listening to different groups, they have the same configuration key name。no longer throw exception