### PR TITLE
[fix] on empty config throw ArgumentNullException

### DIFF
--- a/samples/App3/ConfigFilters/MyNacosConfigFilter.cs
+++ b/samples/App3/ConfigFilters/MyNacosConfigFilter.cs
@@ -83,6 +83,9 @@
 
         public static string? AESDecrypt(string data, string key)
         {
+            if (string.IsNullOrEmpty(data))
+                return null;
+
             byte[] encryptedBytes = Convert.FromBase64String(data);
             byte[] bKey = new byte[32];
             Array.Copy(Encoding.UTF8.GetBytes(key.PadRight(bKey.Length)), bKey, bKey.Length);


### PR DESCRIPTION
## An unhandled exception occurred while processing the request.
```
ArgumentNullException: Value cannot be null. (Parameter 's')
System.Convert.FromBase64String(string s)
```