### PR TITLE
Some optimize

### DIFF
--- a/src/Nacos/Utils/NetUtils.cs
+++ b/src/Nacos/Utils/NetUtils.cs
@@ -12,9 +12,9 @@
         private static readonly string CLIENT_LOCAL_IP_PROPERTY = "com.alibaba.nacos.client.local.ip";
         private static string localIp;
 
-        public static string LocalIP()
+        public static string LocalIP(bool isOverload = false)
         {
-            if (localIp.IsNotNullOrWhiteSpace()) return localIp;
+            if (localIp.IsNotNullOrWhiteSpace() && !isOverload) return localIp;
 
             var val = EnvUtil.GetEnvValue(CLIENT_LOCAL_IP_PROPERTY);
 

--- a/src/Nacos/Utils/TenantUtil.cs
+++ b/src/Nacos/Utils/TenantUtil.cs
@@ -36,7 +36,7 @@
                 tmp = EnvUtil.GetEnvValue("ans.namespace");
             }
 
-            return tmp;
+            return tmp ?? string.Empty;
         }
     }
 }


### PR DESCRIPTION
1. `NetUtils`下`localIp` 为静态变量，`LocalIP`初始化后无法改变，加入了是否重载参数，主要便于单元测试
2. `TenantUtil`下`GetUserTenantForAns`在获取不到值时会返回`null`，现调整为与`GetUserTenantForAcm`一致，`null`时返回`empty`