### PR TITLE
Fix UriTool to retrieve correct IP when preferredNetworks is null

### DIFF
--- a/src/Nacos.AspNetCore/UriTool.cs
+++ b/src/Nacos.AspNetCore/UriTool.cs
@@ -142,7 +142,8 @@ namespace Nacos.AspNetCore
                 // 获取所有可用网卡IP信息
                 var ipCollection = nics?.Select(x => x.GetIPProperties())?.SelectMany(x => x.UnicastAddresses);
 
-                var preferredNetworksArr = preferredNetworks.Split(",");
+                var preferredNetworksArr = string.IsNullOrEmpty(preferredNetworks)
+                    ? new string[0] : preferredNetworks.Split(",");
                 foreach (var ipadd in ipCollection)
                 {
                     if (!IPAddress.IsLoopback(ipadd.Address) &&


### PR DESCRIPTION
related issue #335 